### PR TITLE
Fix duplicate autocomplete suggestions

### DIFF
--- a/application/src/app/components/quiz/quiz.component.ts
+++ b/application/src/app/components/quiz/quiz.component.ts
@@ -269,7 +269,7 @@ export class QuizComponent implements OnInit {
             if (this.trackprev[i].track.preview_url == null) {
               continue;
             } else {
-              if (!songIsDuplicate(this.trackprev[i], this.tracks)) {
+              if (!songIsDuplicate(this.trackprev[i].track, this.tracks)) {
                 this.tracks.push(this.trackprev[i].track);
                 this.playtracks.push(this.trackprev[i]);
                 this.trackopt.push({
@@ -346,7 +346,7 @@ export class QuizComponent implements OnInit {
             if (this.trackprev[i].track.preview_url == null) {
               continue;
             } else {
-              if (!songIsDuplicate(this.trackprev[i], this.tracks)) {
+              if (!songIsDuplicate(this.trackprev[i].track, this.tracks)) {
                 this.tracks.push(this.trackprev[i].track);
                 this.playtracks.push(this.trackprev[i]);
                 this.trackopt.push({


### PR DESCRIPTION
Hello there,

I stumbled upon this project and I must say I really liked it.

One thing that I found a little annoying was that some songs were included twice in the autocomplete suggestions. (Or with a playlist of ~105 songs, nearly 4 times on average) One time, the same song even appeared multiple times in one game.

Here's a fix to that (in `quiz.component.ts`, `songIsDuplicate` was called with the track-in-playlist info, but expected the track itself - so it always returned false). (Note that /me/top returns the track itself, so there's no need for changes there)

Since it seemed like a fun challenge, I optimized the api calls so that they don't overlap. They will now
 - fetch all songs exactly once if there are less than 400 songs in a playlist (resulting in at most 4 API calls, as before)
 - or fetch 400 songs of random 100-sized intervals, evenly distributed over the interval of total songs (also 4 API calls).

I thought it's a cool optimization which directly improves user experience (more songs => better autocomplete suggestions) with totally negligible performance cost, but if you think it adds useless complexity I can remove it as the duplication issue was already solved otherwise.

Since no duplicate songs are fetched anymore, the initial fix described above won't actually be needed (and only takes effect if the playlist includes the same song multiple times). Including it here still felt like the right thing to do.

It's all (manually) tested; the bug is fixed and top/saved/playlist all still work.

If you got any questions or irritations, feel free to leave some questions/feedback here.

Oh, and I'm assuming `master` is the right target branch (not `dev`), right?