### PR TITLE
press return again to go to the next question

### DIFF
--- a/application/src/app/components/quiz/quiz.component.ts
+++ b/application/src/app/components/quiz/quiz.component.ts
@@ -549,7 +549,9 @@ export class QuizComponent implements OnInit {
   checkAns(submission, ans) {
     this.stopAudio();
     this.endTimer();
-    if (this.submitted) return;
+    if (this.submitted) {
+        this.nextPage();
+    }
     this.submitted = true;
     this.partialArtist = false;
     // checks answer after getting thing from event emitter


### PR DESCRIPTION
I love this game, but I would like to be able to play without using the mouse. The only thing stopping me is that you can't continue to the next question after making a guess without clicking the 'Continue' button on the answer component.

I haven't tested this commit, but this seems like the simplest way to get this to work. After the answer pops up, the search box is still focused and you can still press enter in it. Instead of ignoring the calls to `checkAns` after the answer is shown, the app could just go to the next page instead.

The only drawback I can think of is that someone might press enter just after the timer goes off and not see the answer. A better solution might be to use a different key to continue after submitting.